### PR TITLE
Add a syndication runner and settings helper class

### DIFF
--- a/includes-new/admin/class-post-edit-screen.php
+++ b/includes-new/admin/class-post-edit-screen.php
@@ -12,15 +12,17 @@ class Post_Edit_Screen {
 	}
 
 	public function add_post_metaboxes() {
-
+		global $settings_manager;
 		// return if no post types supports push syndication
-		if( empty( $this->push_syndicate_settings['selected_post_types'] ) )
+		if( empty( $settings_manager->get_setting( 'selected_post_types' ) ) ) {
 			return;
+		}
 
-		if( !$this->current_user_can_syndicate() )
+		if( ! $this->current_user_can_syndicate() ) {
 			return;
+		}
 
-		$selected_post_types = $this->push_syndicate_settings[ 'selected_post_types' ];
+		$selected_post_types = $settings_manager->get_setting( 'selected_post_types' );
 		foreach( $selected_post_types as $selected_post_type ) {
 			add_meta_box( 'syndicatediv', __( ' Syndicate ' ), array( $this, 'add_syndicate_metabox' ), $selected_post_type, 'side', 'high' );
 			//add_meta_box( 'syndicationstatusdiv', __( ' Syndication Status ' ), array( $this, 'add_syndication_status_metabox' ), $selected_post_type, 'normal', 'high' );

--- a/includes-new/admin/class-settings-screen.php
+++ b/includes-new/admin/class-settings-screen.php
@@ -9,30 +9,11 @@ namespace Automattic\Syndication\Admin;
 
 class Settings_Screen {
 
-	protected $push_syndicate_default_settings;
-
-	protected $push_syndicate_settings;
 
 	public function __construct() {
 
-		add_action( 'init', array( $this, 'init' ) );
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 		add_action( 'admin_menu', array( $this, 'register_syndicate_settings' ) );
-	}
-
-	public function init() {
-
-		$this->push_syndicate_default_settings = array(
-			'selected_pull_sitegroups'  => array(),
-			'selected_post_types'       => array( 'post' ),
-			'delete_pushed_posts'       => 'off',
-			'pull_time_interval'        => '3600',
-			'update_pulled_posts'       => 'off',
-			'client_id'                 => '',
-			'client_secret'             => ''
-		);
-
-		$this->push_syndicate_settings = wp_parse_args( (array) get_option( 'push_syndicate_settings' ), $this->push_syndicate_default_settings );
 	}
 
 	public function admin_init() {
@@ -41,6 +22,13 @@ class Settings_Screen {
 		register_setting( 'push_syndicate_settings', 'push_syndication_max_pull_attempts', array( $this, 'validate_max_pull_attempts' ) );
 	}
 
+	/**
+	 * Validate the push syndication settings.
+	 *
+	 * @param $raw_settings array Settings to validate.
+	 *
+	 * @return array              Validated settings.
+	 */
 	public function push_syndicate_settings_validate( $raw_settings ) {
 
 		$settings                               = array();
@@ -121,7 +109,7 @@ class Settings_Screen {
 	}
 
 	public function display_pull_sitegroups_selection() {
-
+		global $settings_manager;
 		// get all sitegroups
 		$sitegroups = get_terms( 'syn_sitegroup', array(
 			'fields'        => 'all',
@@ -142,7 +130,7 @@ class Settings_Screen {
 
 			<p>
 				<label>
-					<input type="checkbox" name="push_syndicate_settings[selected_pull_sitegroups][]" value="<?php echo esc_html( $sitegroup->slug ); ?>" <?php $this->checked_array( $sitegroup->slug, $this->push_syndicate_settings['selected_pull_sitegroups'] ) ?> />
+					<input type="checkbox" name="push_syndicate_settings[selected_pull_sitegroups][]" value="<?php echo esc_html( $sitegroup->slug ); ?>" <?php $this->checked_array( $sitegroup->slug, $settings_manager->get_setting( 'selected_pull_sitegroups' ) ) ?> />
 					<?php echo esc_html( $sitegroup->name ); ?>
 				</label>
 				<?php echo esc_html( $sitegroup->description ); ?>
@@ -159,7 +147,8 @@ class Settings_Screen {
 	}
 
 	public function display_time_interval_selection() {
-		echo '<input type="text" size="10" name="push_syndicate_settings[pull_time_interval]" value="' . esc_attr( $this->push_syndicate_settings['pull_time_interval'] ) . '"/>';
+		global $settings_manager;
+		echo '<input type="text" size="10" name="push_syndicate_settings[pull_time_interval]" value="' . esc_attr( $settings_manager->get_setting( 'pull_time_interval' ) ) . '"/>';
 	}
 
 	/**
@@ -195,9 +184,10 @@ class Settings_Screen {
 	}
 
 	public function display_update_pulled_posts_selection() {
+		global $settings_manager;
 		// @TODO refractor this
 		echo '<input type="checkbox" name="push_syndicate_settings[update_pulled_posts]" value="on" ';
-		echo checked( $this->push_syndicate_settings['update_pulled_posts'], 'on' ) . ' />';
+		echo checked( $settings_manager->get_setting( 'update_pulled_posts' ), 'on' ) . ' />';
 	}
 
 	public function display_push_post_types_description() {
@@ -205,7 +195,7 @@ class Settings_Screen {
 	}
 
 	public function display_post_types_selection() {
-
+		global $settings_manager;
 		// @TODO add more suitable filters
 		$post_types = get_post_types( array( 'public' => true ) );
 
@@ -217,7 +207,7 @@ class Settings_Screen {
 
 			<li>
 				<label>
-					<input type="checkbox" name="push_syndicate_settings[selected_post_types][]" value="<?php echo esc_attr( $post_type ); ?>" <?php echo $this->checked_array( $post_type, $this->push_syndicate_settings['selected_post_types'] ); ?> />
+					<input type="checkbox" name="push_syndicate_settings[selected_post_types][]" value="<?php echo esc_attr( $post_type ); ?>" <?php echo $this->checked_array( $post_type, $settings_manager->get_setting( 'selected_post_types' ) ); ?> />
 					<?php echo esc_html( $post_type ); ?>
 				</label>
 			</li>
@@ -235,17 +225,20 @@ class Settings_Screen {
 	}
 
 	public function display_delete_pushed_posts_selection() {
+		global $settings_manager;
 		// @TODO refractor this
 		echo '<input type="checkbox" name="push_syndicate_settings[delete_pushed_posts]" value="on" ';
-		echo checked( $this->push_syndicate_settings['delete_pushed_posts'], 'on' ) . ' />';
+		echo checked( $settings_manager->get_setting( 'delete_pushed_posts' ), 'on' ) . ' />';
 	}
 
 	public function display_client_id() {
-		echo '<input type="text" size=100 name="push_syndicate_settings[client_id]" value="' . esc_attr( $this->push_syndicate_settings['client_id'] ) . '"/>';
+		global $settings_manager;
+		echo '<input type="text" size=100 name="push_syndicate_settings[client_id]" value="' . esc_attr( $settings_manager->get_setting( 'client_id' ) ) . '"/>';
 	}
 
 	public function display_client_secret() {
-		echo '<input type="text" size=100 name="push_syndicate_settings[client_secret]" value="' . esc_attr( $this->push_syndicate_settings['client_secret'] ) . '"/>';
+		global $settings_manager;
+		echo '<input type="text" size=100 name="push_syndicate_settings[client_secret]" value="' . esc_attr( $settings_manager->get_setting( 'client_secret' ) ) . '"/>';
 	}
 
 	public function display_sitegroups_selection() {

--- a/includes-new/class-bootstrap.php
+++ b/includes-new/class-bootstrap.php
@@ -22,6 +22,10 @@ class Bootstrap {
 		new Custom_Taxonomies\Sitegroup_Taxonomy();
 		new Cron();
 
+		// Settings helper.
+		global $settings_manager;
+		$settings_manager = new Syndication_Settings();
+
 		global $client_manager;
 		$client_manager = new Client_Manager();
 
@@ -40,6 +44,9 @@ class Bootstrap {
 		new Admin\Site_List_Screen();
 		new Admin\Site_Edit_Screen( $client_manager );
 		new Admin\Post_Edit_Screen();
+
+		// Load the runner.
+		new Syndication_Runner();
 
 		// Bootstrap individual built-in clients.
 		new Clients\Test\Bootstrap();

--- a/includes-new/class-syndication-runner.php
+++ b/includes-new/class-syndication-runner.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace Automattic\Syndication;
+
+/**
+ * Syndication
+ *
+ * The role of the syndication runner is to manage the site pull/push processes.
+ * Sets up cron schedule whenever pull sites are added
+ * or removed and handles management of individual cron jobs per site.
+ * Automatically disables feed with multiple failures.
+ *
+ * @package Automattic\Syndication
+ */
+class Syndication_Runner {
+	const CUSTOM_USER_AGENT = 'WordPress/Syndication Plugin';
+
+	public  $push_syndicate_transports;
+
+
+	/**
+	 * Set up the Syndication Runner.
+	 */
+	function __construct() {
+
+		// adding custom time interval
+		add_filter( 'cron_schedules', array( $this, 'cron_add_pull_time_interval' ) );
+
+		// Post saved changed or deleted, firing a cron jobs.
+		add_action( 'transition_post_status', array( $this, 'pre_schedule_push_content' ), 10, 3 );
+		add_action( 'delete_post', array( $this, 'schedule_delete_content' ) );
+
+		// Handle changes to sites and site groups, reset cron jobs.
+		add_action( 'save_post',   array( $this, 'handle_site_change' ) );
+		add_action( 'delete_post', array( $this, 'handle_site_change' ) );
+		add_action( 'create_term', array( $this, 'handle_site_group_change' ), 10, 3 );
+		add_action( 'delete_term', array( $this, 'handle_site_group_change' ), 10, 3 );
+
+
+		// Generic hook for reprocessing all scheduled pull jobs. This allows
+		// for bulk rescheduling of jobs that were scheduled the old way (one job
+		// for many sites).
+		add_action( 'syn_refresh_pull_jobs', array( $this, 'refresh_pull_jobs' ) );
+
+		$this->register_syndicate_actions();
+
+		// Legacy action.
+		do_action( 'syn_after_setup_server' );
+
+	}
+
+	public function init() {
+		$this->version = get_option( 'syn_version' );
+	}
+
+	/**
+	 * Set up syndication callback hooks.
+	 */
+	public function register_syndicate_actions() {
+		add_action( 'syn_schedule_push_content', array( $this, 'schedule_push_content' ), 10, 2 );
+		add_action( 'syn_schedule_delete_content', array( $this, 'schedule_delete_content' ) );
+
+		add_action( 'syn_push_content', array( $this, 'push_content' ) );
+		add_action( 'syn_delete_content', array( $this, 'delete_content' ) );
+		add_action( 'syn_pull_content', array( $this, 'pull_content' ), 10, 1 );
+	}
+
+	public function syndication_user_agent( $user_agent ) {
+		return apply_filters( 'syn_pull_user_agent', self::CUSTOM_USER_AGENT );
+	}
+
+	/**
+	 * Pull a single site.
+	 *
+	 * @param  site_id string The site to pull.
+	 *
+	 * @return Array          An array of updated and added post ids.
+	 */
+	function pull_site( $site_id ) {
+		global $client_manager;
+
+		// Fetch the site's client/transport type name
+		$client_transport_type = get_post_meta( $site_id, 'syn_transport_type', true );
+
+		// Fetch the site's client by name
+		$client_details = $client_manager->get_pull_client( $client_transport_type );
+
+		// Run the client's process_site method
+		$client            = new $client_details['class'];
+		$updated_post_ids  = array();
+
+		$processed_posts   = $client->process_site( $site_id, $client );
+
+		/**
+		 * Always return only the processed post IDs.
+		 */
+		if ( $processed_posts ) {
+
+			$updated_post_data = wp_list_pluck( $processed_posts, 'post_data' );
+			$updated_post_ids  = wp_list_pluck( $updated_post_data, 'ID' );
+		}
+
+		return ( $updated_post_ids );
+	}
+
+	public function pull_content( $sites = array() ) {
+		global $site_manager;
+
+		add_filter( 'http_headers_useragent', array( $this, 'syndication_user_agent' ) );
+
+		if ( empty( $sites ) ) {
+			$sites = $site_manager->pull_get_selected_sites();
+		}
+
+		$enabled_sites = $site_manager->get_sites_by_status( 'enabled' );
+		$sites         = array_intersect( $sites, $enabled_sites );
+
+		// Treat this process as an import.
+		if ( ! defined( 'WP_IMPORTING' ) ) {
+			define( 'WP_IMPORTING', true );
+		}
+
+		// Temporarily suspend comment and term counting and cache invalidation.
+		wp_defer_term_counting( true );
+		wp_defer_comment_counting( true );
+		wp_suspend_cache_invalidation( true );
+
+		// Keep track of posts that are added or changed.
+		$updated_post_ids = array();
+		//error_log( 'pull' );
+		//error_log( json_encode( $sites ) );
+
+		foreach( $sites as $site_id ) {
+
+			$site_updated_post_ids = $this->pull_site( $site_id );
+			$updated_post_ids      = array_merge( $updated_post_ids, $site_updated_post_ids );
+
+			update_post_meta( $site_id, 'syn_last_pull_time', current_time( 'timestamp', 1 ) );
+		}
+
+		// Resume comment and term counting and cache invalidation.
+		wp_suspend_cache_invalidation( false );
+		wp_defer_term_counting( false );
+		wp_defer_comment_counting( false );
+
+		// Clear the caches for any posts that were updated.
+		foreach ( $updated_post_ids as $updated_post_id ) {
+			clean_post_cache( $updated_post_id );
+		}
+
+		remove_filter( 'http_headers_useragent', array( $this, 'syndication_user_agent' ) );
+	}
+
+
+	/**
+	 * Handle save_post and delete_post for syn_site posts. If a syn_site post
+	 * is updated or deleted we should reprocess any scheduled pull jobs.
+	 *
+	 * @param $post_id
+	 */
+	public function handle_site_change( $post_id ) {
+		if ( 'syn_site' === get_post_type( $post_id ) ) {
+			$this->refresh_pull_jobs();
+		}
+	}
+	/**
+	 * Reschedule all scheduled pull jobs.
+	 */
+	public function refresh_pull_jobs()	{
+		global $site_manager;
+		$sites         = $site_manager->pull_get_selected_sites();
+		$enabled_sites = $site_manager->get_sites_by_status( 'enabled' );
+		$sites         = array_intersect( $sites, $enabled_sites );
+		$this->schedule_pull_content( $sites );
+	}
+
+	/**
+	 * Schedule the pull content cron jobs.
+	 *
+	 * @param $sites Array Sites that need to be scheduled
+	 */
+	public function schedule_pull_content( $sites ) {
+
+		// to unschedule a cron we need the original arguments passed to schedule the cron
+		// we are saving it as a site option
+		$old_pull_sites = get_option( 'syn_old_pull_sites' );
+
+
+		// Clear all previously scheduled jobs.
+		if( ! empty( $old_pull_sites ) ) {
+			// Clear any jobs that were scheduled the old way: one job to pull many sites.
+			wp_clear_scheduled_hook( 'syn_pull_content', array( $old_pull_sites ) );
+
+			// Clear any jobs that were scheduled the new way: one job to pull one site.
+			foreach ( $old_pull_sites as $old_pull_site ) {
+				wp_clear_scheduled_hook( 'syn_pull_content', array( $old_pull_site ) );
+			}
+
+			wp_clear_scheduled_hook( 'syn_pull_content' );
+		}
+
+		// Schedule new jobs: one job for each site.
+		foreach ( $sites as $site ) {
+			wp_schedule_event(
+				time() - 1,
+				'syn_pull_time_interval',
+				'syn_pull_content',
+				array( array( $site ) )
+			);
+		}
+
+		update_option( 'syn_old_pull_sites', $sites );
+	}
+
+	/**
+	 * Fire events right before scheduling push content.
+	 *
+	 * @param $new_status
+	 * @param $old_status
+	 * @param $post
+	 */
+	public function pre_schedule_push_content( $new_status, $old_status, $post ) {
+
+		// Don't fire on autosave.
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		// if our nonce isn't there, or we can't verify it return
+		if( ! isset( $_POST['syndicate_noncename'] ) || ! wp_verify_nonce( $_POST['syndicate_noncename'], plugin_basename( __FILE__ ) ) ) {
+			return;
+		}
+
+		// Varify user capabilities.
+		if( ! $this->current_user_can_syndicate() ) {
+			return;
+		}
+
+		$sites = $this->get_sites_by_post_ID( $post->ID );
+
+		if ( empty( $sites['selected_sites'] ) && empty( $sites['removed_sites'] ) ) {
+			return;
+		}
+
+		do_action( 'syn_schedule_push_content', $post->ID, $sites );
+	}
+
+	/**
+	 * Handle create_term and delete_term for syn_sitegroup terms. If a site
+	 * group is created or deleted we should reprocess any scheduled pull jobs.
+	 *
+	 * @param $term
+	 * @param $tt_id
+	 * @param $taxonomy
+	 */
+	public function handle_site_group_change ( $term, $tt_id, $taxonomy ) {
+		if ( 'syn_sitegroup' === $taxonomy ) {
+			$this->refresh_pull_jobs();
+		}
+	}
+
+	public function cron_add_pull_time_interval( $schedules ) {
+		global $settings_manager;
+
+		// Adds the custom time interval to the existing schedules.
+		$schedules['syn_pull_time_interval'] = array(
+			'interval' => intval( $settings_manager->get_setting( 'pull_time_interval' ) ),
+			'display'  => esc_html__( 'Pull Time Interval', 'push-syndication' )
+		);
+
+		return $schedules;
+
+	}
+
+}

--- a/includes-new/class-syndication-settings.php
+++ b/includes-new/class-syndication-settings.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Automattic\Syndication;
+
+/**
+ * Syndication Settings
+ *
+ * The role of the syndication settings class is to initialize and
+ * retrieve all syndication settings.
+ *
+ * @package Automattic\Syndication
+ */
+class Syndication_Settings {
+
+	protected $push_syndicate_default_settings;
+	protected $push_syndicate_settings;
+
+	/**
+	 * Construct the Syndication Settings class.
+	 */
+	function __construct() {
+		add_action( 'init', [ $this, 'init' ] );
+	}
+
+	/**
+	 * Set up the syndication settings, combining defaults with stored options.
+	 */
+	public function init() {
+
+		$this->push_syndicate_default_settings = array(
+			'selected_pull_sitegroups'  => array(),
+			'selected_post_types'       => array( 'post' ),
+			'delete_pushed_posts'       => 'off',
+			'pull_time_interval'        => '3600',
+			'update_pulled_posts'       => 'off',
+			'client_id'                 => '',
+			'client_secret'             => ''
+		);
+
+		/**
+		 * Merge the values stored in options with the default values.
+		 */
+		$this->push_syndicate_settings = wp_parse_args(
+											(array) get_option( 'push_syndicate_settings' ),
+											$this->push_syndicate_default_settings
+										 );
+	}
+
+	/**
+	 * Get a setting value.
+	 *
+	 * @param $setting_id string The id of the setting to retrieve.
+	 *
+	 * @return mixed             The setting value, or false if unset.
+	 */
+	public function get_setting( $setting_id ) {
+		return isset( $this->push_syndicate_settings[ $setting_id ] ) ? $this->push_syndicate_settings[ $setting_id ] : false;
+	}
+
+}

--- a/includes-new/clients/xml-pull/class-site-options.php
+++ b/includes-new/clients/xml-pull/class-site-options.php
@@ -343,7 +343,7 @@ class Site_Options {
 		$node_config['namespace']  = sanitize_text_field( $_POST['namespace'] );
 		$node_config['post_root']  = sanitize_text_field( $_POST['post_root'] );
 		$node_config['enc_parent'] = sanitize_text_field( $_POST['enc_parent'] );
-		$node_config['categories'] = is_array( $_POST['categories'] ) ? array_map( 'intval', $_POST['categories'] ) : array();
+		$node_config['categories'] = isset( $_POST['categories'] ) && is_array( $_POST['categories'] ) ? array_map( 'intval', $_POST['categories'] ) : array();
 		$node_config['nodes']      = $custom_nodes;
 		update_post_meta( $site_id, 'syn_node_config', $node_config );
 		return true;


### PR DESCRIPTION
- The role of the syndication runner is to manage the site pull/push processes.
- The role of the syndication settings class is to initialize and retrieve all syndication settings.
- Switch to using new settings helper throughout plugin.
- Remove settings setup code from settings screen class.
- New code for updating existing items in pull client.
- Squash some bugs/php notices
- Implemented function `get_sites_by_ID
- Correctly track sites by site_status, only scheduling or running 'enabled' sites
- Note: some development ongoing for these new classes
